### PR TITLE
Renamed PayPalAPIInterfaceServiceService to ButtonManagerService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### CHANGELOG
 
+####Version 4.0.0 - Mar 27, 2017
+   - Renamed `PayPalAPIInterfaceServiceService` to `ButtonManagerService`.
+   
+
 ####Version 3.9.0 - Sep 22, 2015
    - Updated IPN Endpoint
 

--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ For example,
 	$buttonSearchReq->BMButtonSearchRequest = new BMButtonSearchRequestType();
 	......
 
-	$paypalService = new PayPalAPIInterfaceServiceService($config);
-	$buttonSearchResponse = $paypalService->BMButtonSearch($buttonSearchReq);
+	$buttonManagerService = new ButtonManagerService($config);
+	$buttonSearchResponse = $buttonManagerService->BMButtonSearch($buttonSearchReq);
 	
 	if($strtoupper($buttonSearchResponse->Ack) == 'SUCCESS') {
 		// Success
@@ -102,7 +102,7 @@ For example,
 The SDK provides multiple ways to authenticate your API call.
 
 ```php
-	$paypalService = new PayPalAPIInterfaceServiceService($config);
+	$buttonManagerService = new ButtonManagerService($config);
 	
 	// Use the default account (the first account) configured in sdk_config.ini
 	$response = $paypalService->BMButtonSearch($buttonSearchReq);	

--- a/README.md
+++ b/README.md
@@ -1,50 +1,21 @@
-
 # PayPal PHP ButtonManager SDK
 
-## POODLE Update
-- Because of the Poodle vulnerability, PayPal has disabled SSLv3.
-- To enable TLS encryption, the changes were made to [PPHttpConfig.php](https://github.com/paypal/sdk-core-php/blob/master/lib/PayPal/Core/PPHttpConfig.php#L11) in [SDK Core](https://github.com/paypal/sdk-core-php/) to use a cipher list specific to TLS encryption.
-``` php
-    /**
-	 * Some default options for curl
-	 * These are typically overridden by PPConnectionManager
-	 */
-	public static $DEFAULT_CURL_OPTS = array(
-		CURLOPT_SSLVERSION => 1,
-		CURLOPT_CONNECTTIMEOUT => 10,
-		CURLOPT_RETURNTRANSFER => TRUE,
-		CURLOPT_TIMEOUT        => 60,	// maximum number of seconds to allow cURL functions to execute
-		CURLOPT_USERAGENT      => 'PayPal-PHP-SDK',
-		CURLOPT_HTTPHEADER     => array(),
-		CURLOPT_SSL_VERIFYHOST => 2,
-		CURLOPT_SSL_VERIFYPEER => 1,
-		CURLOPT_SSL_CIPHER_LIST => 'TLSv1',
-	);
-```
-- There are two primary changes done to curl options:
-    - CURLOPT_SSLVERSION is set to 1 . See [here](http://curl.haxx.se/libcurl/c/CURLOPT_SSLVERSION.html) for more information
-    - CURLOPT_SSL_CIPHER_LIST was set to TLSv1, See [here](http://curl.haxx.se/libcurl/c/CURLOPT_SSL_CIPHER_LIST.html) for more information
+## Migrating from 3.x to 4.x
 
-All these changes are included in the recent release, along with many other bug fixes. We highly encourage you to update your versions, by either using `composer` or running this command shown below:
+We have made a change to 4.x to make it compatible with other PayPal Classic SDKs.
 
-```
-curl -L https://raw.github.com/paypal/buttonmanager-sdk-php/stable-php5.3/samples/install.php | php
-        OR
-wget  https://raw.github.com/paypal/buttonmanager-sdk-php/stable-php5.3/samples/install.php
-php install.php
-```
-
+- Change references from `\PayPal\Service\PayPalAPIInterfaceServiceService` to `\PayPal\Service\ButtonManagerService`.
 
 ## Prerequisites
 
-PayPal's PHP ButtonManager SDK requires 
+PayPal's PHP ButtonManager SDK requires:
 
-   * PHP 5.3 and above 
-   * curl/openssl PHP extensions 
+   * PHP 5.3 and above
+   * curl/openssl PHP extensions
  
 ## Running the sample
 
-To run the bundled sample, first copy the samples folder to your web server root. You will then need to install the SDK as a dependency using either composer (PHP V5.3+ only).
+To run the bundled sample, first copy the samples folder to your web server root. You will then need to install the SDK as a dependency using either composer (PHP v5.3+ only).
 
 run `composer update` from the samples folder.
 
@@ -57,15 +28,15 @@ To use the SDK,
 {
     "name": "me/shopping-cart-app",
     "require": {
-        "paypal/buttonmanager-sdk-php":"3.*"
+        "paypal/buttonmanager-sdk-php": "4.*"
     }
 }
 ```
 
-   * Install the SDK as a dependency using composer or the install.php script. 
+   * Install the SDK as a dependency using composer or the install.php script.
    * Require `vendor/autoload.php` OR `PPBootStrap.php` in your application depending on whether you used composer or the custom installer.
-   * Choose how you would like to configure the SDK - You can either
-	  * Create a hashmap containing configuration parameters and pass it to the service object OR
+   * Choose how you would like to configure the SDK - You can either:
+      * Create a hashmap containing configuration parameters and pass it to the service object, OR
       * Create a `sdk_config.ini` file and set the PP_CONFIG_PATH constant to point to the directory where this file exists.
    * Instantiate a service wrapper object and a request object as per your project's needs.
    * Invoke the appropriate method on the service object.
@@ -73,28 +44,32 @@ To use the SDK,
 For example,
 
 ```php
-	// Sets config file path(if config file is used) and registers the classloader
+    // Sets config file path(if config file is used) and registers the classloader
     require("PPBootStrap.php");
-	
-	// Array containing credentials and confiuration parameters. (not required if config file is used)
-	$config = array(
+    
+    use PayPal\PayPalAPI\BMButtonSearchReq;
+    use PayPal\PayPalAPI\BMButtonSearchRequestType;
+    use PayPal\PayPalAPI\ButtonManagerService;
+    
+    // Array containing credentials and confiuration parameters. (not required if config file is used)
+    $config = array(
        'mode' => 'sandbox',
        'acct1.UserName' => 'jb-us-seller_api1.paypal.com',
        'acct1.Password' => 'WX4WTU3S8MY44S7F',
        "acct1.Signature" => "AFcWxV21C7fd0v3bYYYRCpSSRl31A7yDhhsPUU2XhtMoZXsWHFxu-RWy"
        .....
     );
-
-	$buttonSearchReq = new BMButtonSearchReq();
-	$buttonSearchReq->BMButtonSearchRequest = new BMButtonSearchRequestType();
-	......
-
-	$buttonManagerService = new ButtonManagerService($config);
-	$buttonSearchResponse = $buttonManagerService->BMButtonSearch($buttonSearchReq);
-	
-	if($strtoupper($buttonSearchResponse->Ack) == 'SUCCESS') {
-		// Success
-	}
+    
+    $buttonSearchReq = new BMButtonSearchReq();
+    $buttonSearchReq->BMButtonSearchRequest = new BMButtonSearchRequestType();
+    ......
+    
+    $buttonManagerService = new ButtonManagerService($config);
+    $buttonSearchResponse = $buttonManagerService->BMButtonSearch($buttonSearchReq);
+    
+    if($strtoupper($buttonSearchResponse->Ack) == 'SUCCESS') {
+        // Success
+    }
 ```
 
 ## Authentication
@@ -102,29 +77,32 @@ For example,
 The SDK provides multiple ways to authenticate your API call.
 
 ```php
-	$buttonManagerService = new ButtonManagerService($config);
-	
-	// Use the default account (the first account) configured in sdk_config.ini
-	$response = $paypalService->BMButtonSearch($buttonSearchReq);	
-
-	// Use a specific account configured in sdk_config.ini
-	$response = $paypalService->BMButtonSearch($buttonSearchReq, 'jb-us-seller_api1.paypal.com');	
-	 
-	// Pass in a dynamically created API credential object
+    use PayPal\Auth\PPCertificateCredential;
+    use PayPal\Auth\PPTokenAuthorization;
+    
+    $buttonManagerService = new ButtonManagerService($config);
+    
+    // Use the default account (the first account) configured in sdk_config.ini
+    $response = $buttonManagerService->BMButtonSearch($buttonSearchReq);
+    
+    // Use a specific account configured in sdk_config.ini
+    $response = $buttonManagerService->BMButtonSearch($buttonSearchReq, 'jb-us-seller_api1.paypal.com');	
+    
+    // Pass in a dynamically created API credential object
     $cred = new PPCertificateCredential("username", "password", "path-to-pem-file");
     $cred->setThirdPartyAuthorization(new PPTokenAuthorization("accessToken", "tokenSecret"));
-	$response = $paypalService->BMButtonSearch($buttonSearchReq, $cred);	
+    $response = $buttonManagerService->BMButtonSearch($buttonSearchReq, $cred);
 ```  
  
 ## SDK Configuration
 
 
-The SDK allows you to configure the following parameters - 
+The SDK allows you to configure the following parameters:
 
-   * Integration mode (sandbox / live)
-   * (Multiple) API account credentials.
+   * Integration mode (`sandbox`/`live`)
+   * (Multiple) API account credentials
    * HTTP connection parameters
-   * Logging 
+   * Logging
 
 Dynamic configuration values can be set by passing a map of credential and config values (if config map is passed the config file is ignored)
 ```php
@@ -134,13 +112,13 @@ Dynamic configuration values can be set by passing a map of credential and confi
        'acct1.Password' => 'WX4WTU3S8MY44S7F'
        .....
     );
-    $service  = new PayPalAPIInterfaceServiceService($config); 
+    $service  = new ButtonManagerService($config); 
 ```
 Alternatively, you can configure the SDK via the sdk_config.ini file. 
   
 ```php
     define('PP_CONFIG_PATH', '/directory/that/contains/sdk_config.ini');
-    $service  = new PayPalAPIInterfaceServiceService();
+    $service  = new ButtonManagerService();
 ```
 
 You can refer full list of configuration parameters in [wiki](https://github.com/paypal/sdk-core-php/wiki/Configuring-the-SDK) page.
@@ -149,7 +127,31 @@ You can refer full list of configuration parameters in [wiki](https://github.com
 
 Please refer to the IPN-README in 'samples/IPN' directory
 
+## POODLE Update
+- Because of the Poodle vulnerability, PayPal has disabled SSLv3.
+- To enable TLS encryption, the changes were made to [PPHttpConfig.php](https://github.com/paypal/sdk-core-php/blob/master/lib/PayPal/Core/PPHttpConfig.php#L11) in [SDK Core](https://github.com/paypal/sdk-core-php/) to use a cipher list specific to TLS encryption.
+``` php
+    /**
+     * Some default options for curl
+     * These are typically overridden by PPConnectionManager
+     */
+    public static $DEFAULT_CURL_OPTS = array(
+        CURLOPT_SSLVERSION => 1,
+        CURLOPT_CONNECTTIMEOUT => 10,
+        CURLOPT_RETURNTRANSFER => TRUE,
+        CURLOPT_TIMEOUT        => 60,   // maximum number of seconds to allow cURL functions to execute
+        CURLOPT_USERAGENT      => 'PayPal-PHP-SDK',
+        CURLOPT_HTTPHEADER     => array(),
+        CURLOPT_SSL_VERIFYHOST => 2,
+        CURLOPT_SSL_VERIFYPEER => 1,
+        CURLOPT_SSL_CIPHER_LIST => 'TLSv1',
+    );
+```
+- There are two primary changes done to curl options:
+    - CURLOPT_SSLVERSION is set to 1 . See [here](http://curl.haxx.se/libcurl/c/CURLOPT_SSLVERSION.html) for more information
+    - CURLOPT_SSL_CIPHER_LIST was set to TLSv1, See [here](http://curl.haxx.se/libcurl/c/CURLOPT_SSL_CIPHER_LIST.html) for more information
+
 ## Links
 
-   * API Reference - https://developer.paypal.com/webapps/developer/docs/classic/api/#bm
-   * If you need help using the SDK, a new feature that you need or have a issue to report, please visit https://github.com/paypal/buttonmanager-sdk-php/issues 
+   * API Reference - https://developer.paypal.com/webapps/developer/docs/classic/api/#button-manager
+   * If you need help using the SDK, an issue to report, please visit https://github.com/paypal/buttonmanager-sdk-php/issues 

--- a/lib/PayPal/Service/ButtonManagerService.php
+++ b/lib/PayPal/Service/ButtonManagerService.php
@@ -15,9 +15,9 @@ use PayPal\PayPalAPI\BMButtonSearchResponseType;
 use PayPal\PayPalAPI\UpdateAuthorizationResponseType;
 
 /**
- * AUTO GENERATED code for PayPalAPIInterfaceService
+ * AUTO GENERATED code for ButtonManager
  */
-class PayPalAPIInterfaceServiceService extends PPBaseService {
+class ButtonManagerService extends PPBaseService {
 
 	// Service Version
 	private static $SERVICE_VERSION = "106.0";

--- a/samples/ButtonManager/BMButtonSearch.php
+++ b/samples/ButtonManager/BMButtonSearch.php
@@ -1,7 +1,7 @@
 <?php
 use PayPal\PayPalAPI\BMButtonSearchReq;
 use PayPal\PayPalAPI\BMButtonSearchRequestType;
-use PayPal\Service\PayPalAPIInterfaceServiceService;
+use PayPal\Service\ButtonManagerService;
 require_once('../PPBootStrap.php');
 
 /*
@@ -25,7 +25,7 @@ $buttonSearchReq->BMButtonSearchRequest = $buttonSearchRequest;
 Creating service wrapper object to make API call and loading
 Configuration::getAcctAndConfig() returns array that contains credential and config parameters
 */
-$paypalService = new PayPalAPIInterfaceServiceService(Configuration::getAcctAndConfig());
+$paypalService = new ButtonManagerService(Configuration::getAcctAndConfig());
 try {
 	/* wrap API method calls on the service object with a try catch */
 	$buttonSearchResponse = $paypalService->BMButtonSearch($buttonSearchReq);

--- a/samples/ButtonManager/BMCreateButton.php
+++ b/samples/ButtonManager/BMCreateButton.php
@@ -4,7 +4,7 @@ use PayPal\PayPalAPI\BMCreateButtonRequestType;
 use PayPal\PayPalAPI\InstallmentDetailsType;
 use PayPal\PayPalAPI\OptionDetailsType;
 use PayPal\PayPalAPI\OptionSelectionDetailsType;
-use PayPal\Service\PayPalAPIInterfaceServiceService;
+use PayPal\Service\ButtonManagerService;
 require_once('../PPBootStrap.php');
 
 /*
@@ -166,7 +166,7 @@ $createButtonReq->BMCreateButtonRequest = $createButtonRequest;
 Creating service wrapper object to make API call and loading
 Configuration::getAcctAndConfig() returns array that contains credential and config parameters
 */
-$paypalService = new PayPalAPIInterfaceServiceService(Configuration::getAcctAndConfig());
+$paypalService = new ButtonManagerService(Configuration::getAcctAndConfig());
 try {
 	$createButtonResponse = $paypalService->BMCreateButton($createButtonReq);
 } catch (Exception $ex) {

--- a/samples/ButtonManager/BMGetButtonDetails.php
+++ b/samples/ButtonManager/BMGetButtonDetails.php
@@ -1,7 +1,7 @@
 <?php
 use PayPal\PayPalAPI\BMGetButtonDetailsReq;
 use PayPal\PayPalAPI\BMGetButtonDetailsRequestType;
-use PayPal\Service\PayPalAPIInterfaceServiceService;
+use PayPal\Service\ButtonManagerService;
 require_once('../PPBootStrap.php');
 
 /*
@@ -20,7 +20,7 @@ $bmGetButtonDetailsReq->BMGetButtonDetailsRequest = $bmGetButtonDetailsReqest;
 Creating service wrapper object to make API call and loading
 Configuration::getAcctAndConfig() returns array that contains credential and config parameters
 */
-$paypalService = new PayPalAPIInterfaceServiceService(Configuration::getAcctAndConfig());
+$paypalService = new ButtonManagerService(Configuration::getAcctAndConfig());
 try {
 	$bmGetButtonDetailsResponse = $paypalService->BMGetButtonDetails($bmGetButtonDetailsReq);
 } catch (Exception $ex) {

--- a/samples/ButtonManager/BMGetInventory.php
+++ b/samples/ButtonManager/BMGetInventory.php
@@ -1,7 +1,7 @@
 <?php
 use PayPal\PayPalAPI\BMGetInventoryReq;
 use PayPal\PayPalAPI\BMGetInventoryRequestType;
-use PayPal\Service\PayPalAPIInterfaceServiceService;
+use PayPal\Service\ButtonManagerService;
 require_once('../PPBootStrap.php');
 
 /*
@@ -17,7 +17,7 @@ $bmGetInventoryReq->BMGetInventoryRequest = $bmGetInventoryReqest;
 /*
 Configuration::getAcctAndConfig() returns array that contains credential and config parameters
 */
-$paypalService = new PayPalAPIInterfaceServiceService(Configuration::getAcctAndConfig());
+$paypalService = new ButtonManagerService(Configuration::getAcctAndConfig());
 try {
 	$bmGetInventoryResponse = $paypalService->BMGetInventory($bmGetInventoryReq);
 } catch (Exception $ex) {

--- a/samples/ButtonManager/BMManageButtonStatus.php
+++ b/samples/ButtonManager/BMManageButtonStatus.php
@@ -1,7 +1,7 @@
 <?php
 use PayPal\PayPalAPI\BMManageButtonStatusReq;
 use PayPal\PayPalAPI\BMManageButtonStatusRequestType;
-use PayPal\Service\PayPalAPIInterfaceServiceService;
+use PayPal\Service\ButtonManagerService;
 require_once('../PPBootStrap.php');
 /*
  * Use the BMManageButtonStatus API operation to change the status of a hosted button. Currently, you can only delete a button 
@@ -27,7 +27,7 @@ $BMManageButtonStatusReq->BMManageButtonStatusRequest = $bmManageButtonStatusReq
 Creating service wrapper object to make API call and loading
 Configuration::getAcctAndConfig() returns array that contains credential and config parameters
 */
-$paypalService = new PayPalAPIInterfaceServiceService(Configuration::getAcctAndConfig());
+$paypalService = new ButtonManagerService(Configuration::getAcctAndConfig());
 try {
 	$bmManageButtonStatusResponse = $paypalService->BMManageButtonStatus($BMManageButtonStatusReq);
 } catch (Exception $ex) {

--- a/samples/ButtonManager/BMSetInventory.php
+++ b/samples/ButtonManager/BMSetInventory.php
@@ -2,7 +2,7 @@
 use PayPal\EBLBaseComponents\ItemTrackingDetailsType;
 use PayPal\PayPalAPI\BMSetInventoryReq;
 use PayPal\PayPalAPI\BMSetInventoryRequestType;
-use PayPal\Service\PayPalAPIInterfaceServiceService;
+use PayPal\Service\ButtonManagerService;
 
 require_once('../PPBootStrap.php');
 
@@ -43,7 +43,7 @@ $bmSetInventoryReq->BMSetInventoryRequest = $bmSetInventoryReqest;
 Creating service wrapper object to make API call and loading
 Configuration::getAcctAndConfig() returns array that contains credential and config parameters
 */
-$paypalService = new PayPalAPIInterfaceServiceService(Configuration::getAcctAndConfig());
+$paypalService = new ButtonManagerService(Configuration::getAcctAndConfig());
 try {
 	$bmSetInventoryResponse = $paypalService->BMSetInventory($bmSetInventoryReq);
 } catch (Exception $ex) {


### PR DESCRIPTION
This is a breaking change. There is a class `PayPalAPIInterfaceServiceService` in [merchant-sdk-php](https://github.com/paypal/merchant-sdk-php/blob/master/lib/PayPal/Service/PayPalAPIInterfaceServiceService.php) as well, which makes this SDK impossible to use along with it. We will need to make a major release if we merge this PR.

- Fixes duplicate class conflict with Merchant SDK.
- Fixes https://github.com/paypal/merchant-sdk-php/issues/97
- Fixes https://github.com/paypal/merchant-sdk-php/issues/137
- Fixes https://github.com/paypal/merchant-sdk-php/issues/112